### PR TITLE
Added permission section in preflight-workflow & multi-checker

### DIFF
--- a/.github/workflows/multi-checker.yml
+++ b/.github/workflows/multi-checker.yml
@@ -20,7 +20,9 @@ on:
     secrets:
       SEMGREP_APP_TOKEN:
         required: true
-
+permissions:
+  contents: read
+  security-events: write
 jobs:
   Repolinter:
     if: ${{ inputs.repolinter }}
@@ -48,8 +50,6 @@ jobs:
     if: ${{ ( inputs.semgrep && contains('pull_request_target', github.event_name) && github.event.action != 'closed' && github.actor != 'dependabot[bot]' ) }}
     name: semgrep/ci
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
 
     container:
       image: semgrep/semgrep:1.125.0

--- a/.github/workflows/prefligh-checker-workflow.yml
+++ b/.github/workflows/prefligh-checker-workflow.yml
@@ -6,6 +6,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+ contents: read
+ security-events: write
+
 jobs:
   checker:
     uses: qualcomm-linux/qli-actions/.github/workflows/multi-checker.yml@main

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+ contents: read
+ security-events: write
+
 jobs:
   checker:
     uses: qualcomm-linux/qli-actions/.github/workflows/multi-checker.yml@main


### PR DESCRIPTION
## Summary
Fix provided for preflight checker workflow after igibek added permission section in multi-checker,  workflow was failing with below error
`Error calling workflow 'qualcomm-linux/qli-actions/.github/workflows/multi-checker.yml@main'. The nested job 'Semgrep' is requesting 'security-events: write', but is only allowed 'security-events: none'.`

Ref: https://github.com/qualcomm-linux/qli-actions/actions/runs/15727996021
